### PR TITLE
Implement LM API token validation and client initialization when indexing

### DIFF
--- a/src/cliIndex.ts
+++ b/src/cliIndex.ts
@@ -56,7 +56,25 @@ async function main() {
     );
   }
 
-  const client = new LMStudioClient();
+  function resolveLmStudioClientOpts(): {
+	clientIdentifier?: string;
+	clientPasskey?: string;
+  } {
+	const token = process.env.LM_API_TOKEN?.trim();
+	if (!token) return {};
+
+	const match = /^sk-lm-([A-Za-z0-9]{8}):([A-Za-z0-9]{20})$/.exec(token);
+	if (!match) {
+	  throw new Error("LM_API_TOKEN is not a valid LM Studio token (sk-lm-xxxxxxxx:yyyyyyyyyyyyyyyyyyyy)");
+	}
+
+	return {
+	  clientIdentifier: match[1],
+	  clientPasskey: match[2],
+	};
+  }
+
+  const client = new LMStudioClient(resolveLmStudioClientOpts());
 
   console.log("[BigRAG CLI] Initializing vector store...");
   const vectorStore = new VectorStore(vectorStoreDir);
@@ -128,5 +146,3 @@ async function main() {
 }
 
 void main();
-
-


### PR DESCRIPTION
I’m using this plugin to programmatically index documents and retrieve them later. Plugins require an API key for REST API requests, but the indexing command did not include authentication support.

This pull request adds a helper that reads the LM_API_TOKEN environment variable, validates its format, automatically extracts the client identifier and passkey, and passes them to the client.

As a result, the indexing command now works whether the server requires authentication or not.